### PR TITLE
fix(web): reduce page revalidation from 1 hour to 60 seconds

### DIFF
--- a/nuvoices-web/src/app/magazine/[slug]/page.tsx
+++ b/nuvoices-web/src/app/magazine/[slug]/page.tsx
@@ -128,7 +128,7 @@ const nextPostQuery = groq`
   }
 `;
 
-export const revalidate = 3600; // Revalidate every hour
+export const revalidate = 60;
 
 export default async function MagazineArticlePage({
   params,

--- a/nuvoices-web/src/app/news/[slug]/page.tsx
+++ b/nuvoices-web/src/app/news/[slug]/page.tsx
@@ -128,7 +128,7 @@ const nextPostQuery = groq`
   }
 `;
 
-export const revalidate = 3600; // Revalidate every hour
+export const revalidate = 60;
 
 export default async function NewsArticlePage({
   params,

--- a/nuvoices-web/src/app/podcast/[slug]/page.tsx
+++ b/nuvoices-web/src/app/podcast/[slug]/page.tsx
@@ -65,7 +65,7 @@ const NAVIGATION_QUERY = groq`{
   }
 }`
 
-export const revalidate = 3600; // Revalidate every hour
+export const revalidate = 60;
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params


### PR DESCRIPTION
Content updates in Sanity were taking up to an hour to appear on the site. Lower revalidation interval so changes show within a minute.